### PR TITLE
Mejora de expresiones regulares Ciclos

### DIFF
--- a/src/main/java/ciclos/PseudocodeProcessorCiclos.java
+++ b/src/main/java/ciclos/PseudocodeProcessorCiclos.java
@@ -56,7 +56,7 @@ public class PseudocodeProcessorCiclos {
     }
 
     private String convertForLoops(String pseudocode) {
-        Pattern pattern = Pattern.compile("(?sm)PARA\\s*([^HAS]+)HASTA\\s*([^EN]+)EN\\s*([^\\s]+)\\s*HACER:\\s*(.*?)\\s*FIN PARA");
+        Pattern pattern = Pattern.compile("(?sm)PARA(.*?)HASTA(.*?)EN(.*?)HACER:(.*?)FIN PARA");
         Matcher matcher = pattern.matcher(pseudocode);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
@@ -64,33 +64,33 @@ public class PseudocodeProcessorCiclos {
             String condition = matcher.group(2).trim();
             String update = matcher.group(3).trim();
             String body = modifyDoWhileBody(matcher.group(4).trim());
-            matcher.appendReplacement(sb, "for (" + initialization + "; " + condition + "; " + update + ") {\n" + body + "\n}");
+            matcher.appendReplacement(sb, "for(" + initialization + "; " + condition + "; " + update + "){\n" + body + "\n}");
         }
         matcher.appendTail(sb);
         return sb.toString();
     }
 
     private String convertWhileLoops(String pseudocode) {
-        Pattern pattern = Pattern.compile("(?s)MIENTRAS\\s*([^HAC)]+)HACER:\\s*(.*?)\\s*FIN MIENTRAS");
+        Pattern pattern = Pattern.compile("(?sm)MIENTRAS(.*?)HACER:(.*?)FIN MIENTRAS");
         Matcher matcher = pattern.matcher(pseudocode);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String condition = matcher.group(1).trim();
             String body = modifyDoWhileBody(matcher.group(2).trim());
-            matcher.appendReplacement(sb, "while (" + condition + ") {\n" + body + "\n}");
+            matcher.appendReplacement(sb, "while (" + condition + "){\n" + body + "\n}");
         }
         matcher.appendTail(sb);
         return sb.toString();
     }
 
     private String convertDoWhileLoops(String pseudocode) {
-        Pattern pattern = Pattern.compile("(?s)REPETIR:\\s*(.*?)\\s*MIENTRAS\\s*([^\\n]+)");
+        Pattern pattern = Pattern.compile("(?sm)REPETIR:(.*?)MIENTRAS(.*?)(\\r|$)");
         Matcher matcher = pattern.matcher(pseudocode);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String body = modifyDoWhileBody(matcher.group(1).trim());
             String condition = matcher.group(2).trim();
-            matcher.appendReplacement(sb, "do {\n" + body + "\n} while (" + condition + ");");
+            matcher.appendReplacement(sb, "do{\n" + body + "\n} while(" + condition + ");");
         }
         matcher.appendTail(sb);
         return sb.toString();


### PR DESCRIPTION
### Descripción 
Se han realizado mejoras en las expresiones regulares de Ciclos PARA, MIENTRAS y REPETIR-MIENTRAS.

A continuación se presenta un ejemplo donde se hace uso de los 3 Ciclos y se puede apreciar su funcionamiento.

Entrada: 
```
PARA ENTERO i = 0 HASTA i < 3 EN i++ HACER:
    IMPRIMIR "Valor de i: " i
    MIENTRAS j < 2 HACER:
        IMPRIMIR "Valor de j: " j
        REPETIR:
            IMPRIMIR "Dentro de Hacer-Mientras, k = " k
            k = k + 1
        MIENTRAS k < 1
        PARA ENTERO l = 0 HASTA l < 2 EN l++ HACER:
            IMPRIMIR "Valor de l: " l
            MIENTRAS m < 1 HACER:
                IMPRIMIR "Valor de m: " m
                REPETIR:
                    IMPRIMIR "Dentro de Hacer-Mientras, n = " n
                    n = n + 1
                MIENTRAS n < 1
            FIN MIENTRAS
        FIN PARA
    FIN MIENTRAS
FIN PARA
```


Salida: 
```
for (ENTERO i = 0; i < 3; i++) {
  IMPRIMIR "Valor de i: "
  i
  while (j < 2) {
    IMPRIMIR "Valor de j: "
    j
    do {
      IMPRIMIR "Dentro de Hacer-Mientras, k = "
      k
      k = k + 1
    } while (k < 1);
    for (ENTERO l = 0; l < 2; l++) {
      IMPRIMIR "Valor de l: "
      l
      while (m < 1) {
        IMPRIMIR "Valor de m: "
        m
        do {
          IMPRIMIR "Dentro de Hacer-Mientras, n = "
          n
          n = n + 1
        } while (n < 1);
      }
    }
  }
}
```

La mejora de las expresiones regulares de Regex solucionan un problema que había al hacer uso de las palabras reservadas HASTA y HACER, así como también se simplificó la expresión haciéndola menos compleja y fácil de comprender.